### PR TITLE
3 lytix diary import externallib

### DIFF
--- a/classes/diary_entries_lib.php
+++ b/classes/diary_entries_lib.php
@@ -27,6 +27,10 @@
  */
 
 namespace lytix_diary;
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once("{$CFG->libdir}/externallib.php");
 
 use lytix_helper\course_settings;
 use lytix_logs\logger;

--- a/version.php
+++ b/version.php
@@ -31,7 +31,8 @@ $plugin->requires = 2022112800.00; // Requires this Moodle version 4.1.
 $plugin->component = 'lytix_diary'; // Full name of the plugin.
 $plugin->dependencies = [
     'lytix_helper' => ANY_VERSION,
-    'lytix_logs' => ANY_VERSION
-    ];
-$plugin->release   = 'v1.0.8';
+    'lytix_logs' => ANY_VERSION,
+    'lytix_config' => ANY_VERSION
+];
+$plugin->release   = 'v1.0.9';
 $plugin->supported = [401, 403];


### PR DESCRIPTION
- Changed the import of externallib to work for both Moodle 4.1 and 4.2+.
- Changed the import to work for Moodle 4.2 and the testmatrix for Moodle 4.2 + PHP 8.2+